### PR TITLE
Fix build config

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -9,6 +9,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
 
 const env = process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -33,11 +34,13 @@ const webpackConfig = merge(baseWebpackConfig, {
       'process.env': env
     }),
     // UglifyJs do not support ES6+, you can also use babel-minify for better treeshaking: https://github.com/babel/minify
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      },
-      sourceMap: true
+    new UglifyJSPlugin({
+      sourceMap: true,
+      uglifyOptions: {
+        compress: {
+          warnings: false
+        }
+      }
     }),
     // extract css into its own file
     new ExtractTextPlugin({

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "shelljs": "^0.7.6",
     "sinon": "^4.0.0",
     "sinon-chai": "^2.8.0",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^0.5.8",
     "vue-chartjs": "^3.0.2",
     "vue-loader": "^13.7.1",


### PR DESCRIPTION
## Overview
Fix a webpack configuration issue that was preventing `npm run build`

## How I resolved it
Require uglify-js-webpack plugin as a dev dependency

...

## How to verify it
1. `npm run build` completes successfully

## Questions

...

## Notes

...

## Screenshots

*all style changes require before and after screenshots*

### Before

### After

Notify the following people: @darrynten @tammygermany @igorsergiichuk @steveops @humanityjs @fergusdixon
