### PR TITLE
fixing uglify error when running `npm run build`

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -9,6 +9,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 const env = process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -33,10 +34,7 @@ const webpackConfig = merge(baseWebpackConfig, {
       'process.env': env
     }),
     // UglifyJs do not support ES6+, you can also use babel-minify for better treeshaking: https://github.com/babel/minify
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      },
+    new UglifyJsPlugin({
       sourceMap: true
     }),
     // extract css into its own file


### PR DESCRIPTION
## Overview
The build is failing because of vue-toaster

Related issues: # https://github.com/darrynten/everframe-dashboard/pull/31

## The problem

`npm run build` is not working

## How I resolved it

Ported same fix that @humanityjs did in everframe-dashboard

## How to verify it

1. Run `npm rub build` before and after.

## Screenshots

*all style changes require before and after screenshots*

### Before

ERROR in static/js/app.6e53b531a198c0be6394.js from UglifyJs
Unexpected token: punc (() [static/js/app.6e53b531a198c0be6394.js:2573,6]

  Build failed with errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! vue-quick-dash@1.0.0 build: `node build/build.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the vue-quick-dash@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/everframe/.npm/_logs/2018-05-03T15_43_31_922Z-debug.log

### After

Works smoothly

Notify the following people: @darrynten @tammygermany @igorsergiichuk @steveops @humanityjs @fergusdixon
