### PR TITLE
Load Admin Routes and Stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Quick Dashboard Framework",
   "author": "Unicorn Global et al",
   "license": "MIT",

--- a/src/router/admin.js
+++ b/src/router/admin.js
@@ -1,6 +1,14 @@
 import config from '@/config'
 import icons from '@/icons'
 
+// Load up any custom admin routes
+let customAdminRoutes = []
+try {
+  customAdminRoutes = require('~/router/admin').default
+} catch {
+  // No custom admin routes exist
+}
+
 const users = config.admin.users ? [
   {
     name: 'AllUsers',
@@ -44,6 +52,7 @@ export default config.admin.enabled ? [
       icon: icons.admin
     },
     children: [
+      ...customAdminRoutes,
       ...users,
       ...settings
     ]

--- a/src/router/admin.js
+++ b/src/router/admin.js
@@ -5,6 +5,7 @@ import icons from '@/icons'
 let customAdminRoutes = []
 try {
   customAdminRoutes = require('~/router/admin').default
+  console.log(customAdminRoutes)
 } catch {
   // No custom admin routes exist
 }
@@ -41,7 +42,7 @@ const settings = config.admin.settings.enabled ? [
   }
 ] : []
 
-export default config.admin.enabled ? [
+const adminRoutes = config.admin.enabled ? [
   {
     name: 'AdminAccount',
     path: 'admin',
@@ -52,9 +53,11 @@ export default config.admin.enabled ? [
       icon: icons.admin
     },
     children: [
-      ...customAdminRoutes,
+      ...customAdminRoutes || [],
       ...users,
       ...settings
     ]
   }
 ] : []
+
+export default adminRoutes

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,6 @@ import { userHasRole } from '@/auth'
  * `/store` folder.
  */
 const reserved = [
-  // 'admin',
   'auth',
   'base',
   'index'

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,7 @@ import { userHasRole } from '@/auth'
  * `/store` folder.
  */
 const reserved = [
-  'admin',
+  // 'admin',
   'auth',
   'base',
   'index'
@@ -78,7 +78,8 @@ async function getCustomRoutes(user) {
       }
 
       // Check non-home routes
-      if (name !== 'home') {
+      // Skip any admin routes
+      if (name !== 'home' && name !== 'admin') {
         customRoutes = [...customRoutes, ...filterRoutesByRole(value, user)]
       }
     })

--- a/src/store/admin.js
+++ b/src/store/admin.js
@@ -5,7 +5,7 @@ let custom = false
 let external = {}
 
 // The framework level store
-let adminStore = {
+const adminStore = {
   namespaced: true,
   state: {
     ...users.state,
@@ -40,7 +40,6 @@ try {
 
 // Load the new custom stores into the namespace
 if (external) {
-  console.log([external])
   Object.keys(external).forEach(function(key) {
     adminStore.state = {
       ...adminStore.state,

--- a/src/store/admin.js
+++ b/src/store/admin.js
@@ -1,7 +1,11 @@
 import users from '@/store/users'
 import roles from '@/store/roles'
 
-export default {
+let custom = false
+let external = {}
+
+// The framework level store
+let adminStore = {
   namespaced: true,
   state: {
     ...users.state,
@@ -16,3 +20,41 @@ export default {
     ...roles.getters
   }
 }
+
+// Load any app level admin only stores
+try {
+  custom = require.context('~/store/admin', true, /\.js$/)
+  custom.keys().forEach(function(key) {
+    const name = /\.\/(\S+)\.js/.exec(key)[1]
+
+    console.log('Found custom admin only store: ', name)
+
+    external = {
+      ...external,
+      [name]: custom(key).default
+    }
+  })
+} catch (e) {
+  console.log('Loading custom admin store error:', e)
+}
+
+// Load the new custom stores into the namespace
+if (external) {
+  console.log([external])
+  Object.keys(external).forEach(function(key) {
+    adminStore.state = {
+      ...adminStore.state,
+      ...external[key].state
+    }
+    adminStore.mutations = {
+      ...adminStore.mutations,
+      ...external[key].mutations
+    }
+    adminStore.getters = {
+      ...adminStore.getters,
+      ...external[key].getters
+    }
+  })
+}
+
+export default adminStore

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -56,7 +56,8 @@ const reserved = [
 ]
 
 try {
-  custom = require.context('~/store', true, /\.js$/)
+  // Load everything _except_ the admin folder
+  custom = require.context('~/store', true, /^((?![\\/]admin[\\/]).)*\.js$/)
   custom.keys().forEach(function(key) {
     const name = /\.\/(\S+)\.js/.exec(key)[1]
 


### PR DESCRIPTION
Allows additional admin routes to be loaded into the admin menu on the sidebar.

Simply place extra admin specific routes in the `~/src/router/admin.js` file.

Allows admin-specific stores to be loaded via the `~/src/store/admin/*.js`

Will load the admin stores up into the `admin/xxx` store namespace.

Will first check if the user has the admin role as configured in the `~/config/admin.js`