### PR TITLE
Custom Home Route Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Quick Dashboard Framework",
   "author": "Unicorn Global et al",
   "license": "MIT",

--- a/src/components/SideBar/SideBar.vue
+++ b/src/components/SideBar/SideBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="menu-element">
-    <router-link class="logo" to="/" v-if="showLogo">
+    <router-link class="logo" :to="homeRoute" v-if="showLogo" @click.native="closeSidebar">
       <component v-if="showLogo" :is="logo"></component>
     </router-link>
     <user-profile v-if="showUserProfile" :user="user"></user-profile>
@@ -44,6 +44,9 @@
       'logout-icon': icons.sign_out
     },
     computed: {
+      homeRoute() {
+        return this.$store.getters['app/config'].header.homeRoute || '/'
+      },
       showUserProfile() {
         if (this.$store.getters['app/config'].sidebar.profile) {
           return 'display: block'
@@ -70,6 +73,11 @@
       }
     },
     methods: {
+      closeSidebar() {
+        if (this.$store.getters['app/sidebar/open']) {
+          this.$store.commit('app/sidebar/open', false)
+        }
+      },
       logout() {
         return this.$auth.logout({
           makeRequest: true,

--- a/src/components/TopNav/TopNav.vue
+++ b/src/components/TopNav/TopNav.vue
@@ -6,10 +6,10 @@
           <hamburger class="hamburger"></hamburger>
         </div>
       </div>
-      <router-link class="logo" to="/" v-if="showLogo">
+      <router-link class="logo" :to="homeRoute" v-if="showLogo">
         <quick></quick>&nbsp;Quick Dash
       </router-link>
-      <router-link class="mobile-logo" to="/" v-if="showMobileLogo">
+      <router-link class="mobile-logo" :to="homeRoute" v-if="showMobileLogo">
         <quick></quick>&nbsp;Quick Dash
       </router-link>
       <div class="page-title">{{pageTitle}}</div>
@@ -128,6 +128,9 @@
       }
     },
     computed: {
+      homeRoute() {
+        return this.$store.getters['app/config'].header.homeRoute || '/'
+      },
       pageTitle() {
         return ''
       },

--- a/src/config/header.js
+++ b/src/config/header.js
@@ -5,6 +5,7 @@ export default {
   mobileLogo: true,
   avatar: true,
   logout: false,
+  homeRoute: '/',
   role: (user) => {
     // Perform some custom code to populate the main role
     // This is compatible with the strong-lumen style

--- a/test/unit/specs/components/SideBar/SideBar.spec.js
+++ b/test/unit/specs/components/SideBar/SideBar.spec.js
@@ -84,6 +84,55 @@ describe('SideBar.vue', () => {
     expect(menu.meta.main).to.equal(true)
   })
 
+  it('accepts a custom home route', () => {
+    const sidebar = shallowMount(SideBar, {
+      localVue,
+      propsData: {
+        user: {},
+        rootPath: '/root',
+        menus: [
+          {
+            name: 'home',
+            path: '/',
+            meta: {
+              icon: 'fa fa-home',
+              label: 'Home',
+              main: true
+            }
+          }
+        ]
+      },
+      mocks: {
+        $route: {
+          name: 'Custom',
+          label: 'Custom',
+          matched: []
+        },
+        $store: {
+          getters: {
+            'app/config': {
+              sidebar: {
+                profile: false,
+                logout: false,
+                icons: true,
+                highlight: false
+              },
+              header: {
+                homeRoute: '/home'
+              }
+            }
+          }
+        }
+      }
+    })
+    expect(sidebar.vm.rootPath).to.equal('/root')
+    expect(sidebar.vm.homeRoute).to.equal('/home')
+    expect(sidebar.vm.showUserProfile).to.equal(undefined)
+    expect(sidebar.vm.showLogo).to.equal(false)
+    expect(sidebar.vm.logo).to.equal(false)
+    expect(sidebar.vm.logoutStyle).to.equal(undefined)
+  })
+
   it('logs out', () => {
     const sidebar = shallowMount(SideBar, {
       localVue,


### PR DESCRIPTION
Allows an application to declare a custom home route for the sidebar logo and their header logo in their `~/src/config/header.js` file.

Defaults to `/`

Bumps version to 2.2.6