### PR TITLE
refactor top bar component to use slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13340,8 +13340,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13362,14 +13361,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13384,20 +13381,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13514,8 +13508,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13527,7 +13520,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13542,7 +13534,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13550,14 +13541,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13576,7 +13565,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -13657,8 +13645,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13670,7 +13657,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13756,8 +13742,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13793,7 +13778,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13813,7 +13797,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13857,14 +13840,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.2.10",
+  "version": "2.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1262,9 +1262,9 @@
       "dev": true
     },
     "@unicorns/avatars": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@unicorns/avatars/-/avatars-2.0.1.tgz",
-      "integrity": "sha512-F2Nvr6lp+uPHrqPnRJIsug+LNkgFjPfa0s/mLzLm+B/hMSuMKuUyn7NMzhA70fSlh19E031QGfbOaExmvWiV1A=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@unicorns/avatars/-/avatars-2.0.3.tgz",
+      "integrity": "sha512-zaLPTF5EliDpqOu6SZU6MSl0D6A/RwSwKN6YK53/9U4wabtGUiT+Hbv3E389Y0DvzXunkcbICvwp0+5+AGmPLA=="
     },
     "@unicorns/data-table": {
       "version": "2.0.4",
@@ -13316,7 +13316,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13337,12 +13338,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13357,17 +13360,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13484,7 +13490,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13496,6 +13503,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13510,6 +13518,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13517,12 +13526,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13541,6 +13552,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -13621,7 +13633,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13633,6 +13646,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13718,7 +13732,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13754,6 +13769,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13773,6 +13789,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13816,12 +13833,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.2.10",
+  "version": "2.2.12",
   "description": "Quick Dashboard Framework",
   "author": "Unicorn Global et al",
   "license": "MIT",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/UnicornGlobal/quick-dash-framework#readme",
   "dependencies": {
-    "@unicorns/avatars": "^2.0.1",
+    "@unicorns/avatars": "^2.0.3",
     "@unicorns/data-table": "^2.0.4",
     "@unicorns/sign-me-up": "^1.0.2",
     "@unicorns/toaster": "^2.0.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,18 +3,14 @@
     <div id="app-component" v-if="loaded">
       <toaster></toaster>
       <transition :name="transitionStyle" v-if="enableSideBar">
-        <side-bar class="side-bar"
-          v-show="showSideBar"
-          :menus="menu"
-          :user="user">
-        </side-bar>
+        <side-bar class="side-bar" v-show="showSideBar" :menus="menu" :user="user"></side-bar>
       </transition>
       <transition name="fade" v-if="enableSideBar">
         <div class="shadow" v-show="showSideBar" @click.prevent="closeSidebar"></div>
       </transition>
       <div class="main-content" :style="layoutStyle">
-        <top-nav class="top-nav" :loaded="loaded" :user="user" :sidebar="enableSideBar" v-if="user"></top-nav>
-        <router-view class="content-area"></router-view>
+        <!-- <top-nav class="top-nav" :loaded="loaded" :user="user" :sidebar="enableSideBar" v-if="user"></top-nav> -->
+        <router-view class="content-area-view"></router-view>
       </div>
     </div>
     <component :is="loaderComponent" width="100px" height="100px" v-else></component>
@@ -22,185 +18,192 @@
 </template>
 
 <script>
-  import SideBar from '@/components/SideBar/SideBar'
-  import TopNav from '@/components/TopNav/TopNav'
-  import Loader from '@/components/Loader'
-  import Toaster from '@unicorns/toaster'
+import SideBar from '@/components/SideBar/SideBar'
+import TopNav from '@/components/TopNav/TopNav'
+import Loader from '@/components/Loader'
+import Toaster from '@unicorns/toaster'
 
-  export default {
-    name: 'app',
-    components: {
-      SideBar,
-      TopNav,
-      Loader,
-      Toaster
+export default {
+  name: 'app',
+  components: {
+    SideBar,
+    TopNav,
+    Loader,
+    Toaster
+  },
+  data() {
+    return {
+      loaderComponent: require('@/components/Loader').default
+    }
+  },
+  created() {
+    try {
+      const customLoader = require('~/components/Loader').default
+      if (customLoader) {
+        this.loaderComponent = customLoader
+      }
+    } catch (e) {
+      // No custom loader is present
+    }
+  },
+  computed: {
+    user() {
+      return this.$store.getters['auth/user']
     },
-    data() {
-      return {
-        loaderComponent: require('@/components/Loader').default
+    loaded() {
+      return !this.$store.getters['app/loading']
+    },
+    showSideBar() {
+      return this.$store.getters['app/sidebar/open']
+    },
+    enableSideBar() {
+      return (
+        this.$store.getters['app/sidebar/enabled'] &&
+        this.$store.getters['app/config'].sidebar.enabled
+      )
+    },
+    layoutStyle() {
+      if (this.$store.getters['app/config'].sidebar.position === 'right') {
+        return 'flex-direction: column'
       }
     },
-    created() {
-      try {
-        const customLoader = require('~/components/Loader').default
-        if (customLoader) {
-          this.loaderComponent = customLoader
-        }
-      } catch (e) {
-        // No custom loader is present
+    transitionStyle() {
+      if (this.$store.getters['app/config'].sidebar.position === 'right') {
+        return 'slideright'
       }
-    },
-    computed: {
-      user() {
-        return this.$store.getters['auth/user']
-      },
-      loaded() {
-        return !this.$store.getters['app/loading']
-      },
-      showSideBar() {
-        return this.$store.getters['app/sidebar/open']
-      },
-      enableSideBar() {
-        return this.$store.getters['app/sidebar/enabled'] && this.$store.getters['app/config'].sidebar.enabled
-      },
-      layoutStyle() {
-        if (this.$store.getters['app/config'].sidebar.position === 'right') {
-          return 'flex-direction: column'
-        }
-      },
-      transitionStyle() {
-        if (this.$store.getters['app/config'].sidebar.position === 'right') {
-          return 'slideright'
-        }
 
-        return 'slideleft'
-      },
-      menu() {
-        const routes = Object.assign([], this.$store.getters['app/routes'][0].children)
-        return routes.filter(function filter(route) {
-          if (route.children) {
-            route.children = route.children.filter(filter)
-          }
-          return (route.meta && route.meta.main) || (route.children && route.children.length)
-        })
-      }
+      return 'slideleft'
     },
-    methods: {
-      closeSidebar() {
-        if (this.$store.getters['app/sidebar/open']) {
-          this.$store.commit('app/sidebar/open', false)
+    menu() {
+      const routes = Object.assign(
+        [],
+        this.$store.getters['app/routes'][0].children
+      )
+      return routes.filter(function filter(route) {
+        if (route.children) {
+          route.children = route.children.filter(filter)
         }
+        return (
+          (route.meta && route.meta.main) ||
+          (route.children && route.children.length)
+        )
+      })
+    }
+  },
+  methods: {
+    closeSidebar() {
+      if (this.$store.getters['app/sidebar/open']) {
+        this.$store.commit('app/sidebar/open', false)
       }
     }
   }
+}
 </script>
 
 <style lang="scss">
-  .wrapper {
-    height: 100%;
+.wrapper {
+  height: 100%;
+}
+
+#app-component {
+  height: 100%;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+
+  .main-content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
-  #app-component {
+  .side-bar {
     height: 100%;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: row;
+    width: 300px;
+    background: $white;
+    z-index: 2;
+    overflow-y: auto;
+    border-right: $sidebar_border;
+    box-shadow: $sidebar_shadow;
 
-    .main-content {
-      width: 100%;
+    @media (max-width: 420px) {
+      border-right: solid 2px $primary-dark;
+      position: fixed;
       display: flex;
       flex-direction: column;
+      justify-content: space-between;
     }
 
-    .side-bar {
+    @media (max-width: 1024px) and (min-width: 421px) {
+      position: fixed;
+    }
+
+    @media (min-width: 1025px) {
+      display: flex !important;
+      flex-direction: column;
       height: 100%;
-      width: 300px;
-      background: $white;
-      z-index: 2;
-      overflow-y: auto;
-      border-right: $sidebar_border;
-      box-shadow: $sidebar_shadow;
-
-      @media (max-width: 420px) {
-        border-right: solid 2px $primary-dark;
-        position: fixed;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-      }
-
-      @media (max-width: 1024px) and (min-width: 421px) {
-        position: fixed;
-      }
-
-      @media (min-width: 1025px) {
-        display: flex !important;
-        flex-direction: column;
-        height: 100%;
-      }
     }
   }
+}
 
-  .slideright-enter-active {
-    transition: all .3s ease;
-  }
+.content-area-view {
+  overflow-y: auto;
+  flex: 1;
+  overflow-x: hidden;
+}
 
-  .slideright-leave-active {
-    transition: all .3s
-  }
+.slideright-enter-active {
+  transition: all 0.3s ease;
+}
 
-  .slideright-enter, .slideright-leave-to {
-    transform: translate3d(100%, 0, 0);
-  }
+.slideright-leave-active {
+  transition: all 0.3s;
+}
 
-  .slideleft-enter-active {
-    transition: all .3s ease;
-  }
+.slideright-enter,
+.slideright-leave-to {
+  transform: translate3d(100%, 0, 0);
+}
 
-  .slideleft-leave-active {
-    transition: all .3s
-  }
+.slideleft-enter-active {
+  transition: all 0.3s ease;
+}
 
-  .slideleft-enter, .slideleft-leave-to {
-    transform: translate3d(-100%, 0, 0);
-  }
+.slideleft-leave-active {
+  transition: all 0.3s;
+}
 
-  .fade-enter-active, .fade-leave-active {
-    transition: opacity .5s
-  }
+.slideleft-enter,
+.slideleft-leave-to {
+  transform: translate3d(-100%, 0, 0);
+}
 
-  .fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */
-  {
-    opacity: 0
-  }
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s;
+}
 
-  .top-nav {
-    width: 100%;
-  }
+.fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */
+ {
+  opacity: 0;
+}
 
-  .content-area {
-    padding: 1em 1.5em;
-    overflow-y: auto;
-    flex: 1;
-    overflow-x: hidden;
+.top-nav {
+  width: 100%;
+}
 
-    @media(max-width: 400px) {
-      margin: 0 auto 0 auto;
-    }
-  }
-
-  .shadow {
-    display: block;
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1;
-    background-color: rgba(0, 0, 0, 0.6);
-  }
+.shadow {
+  display: block;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  background-color: rgba(0, 0, 0, 0.6);
+}
 </style>

--- a/src/components/Containers/PageContainer.vue
+++ b/src/components/Containers/PageContainer.vue
@@ -29,7 +29,7 @@
 </style>
 
 <script>
-import TopNav from "@/components/TopNav/TopNav";
+import TopNav from '@/components/TopNav/TopNav'
 export default {
   props: {
     title: {
@@ -43,17 +43,17 @@ export default {
   },
   computed: {
     user() {
-      return this.$store.getters["auth/user"];
+      return this.$store.getters['auth/user']
     },
     loaded() {
-      return !this.$store.getters["app/loading"];
+      return !this.$store.getters['app/loading']
     },
     enableSideBar() {
       return (
-        this.$store.getters["app/sidebar/enabled"] &&
-        this.$store.getters["app/config"].sidebar.enabled
-      );
+        this.$store.getters['app/sidebar/enabled'] &&
+        this.$store.getters['app/config'].sidebar.enabled
+      )
     }
   }
-};
+}
 </script>

--- a/src/components/Containers/PageContainer.vue
+++ b/src/components/Containers/PageContainer.vue
@@ -13,7 +13,7 @@
 <style lang="scss">
 .page-container {
   background-color: $light-bg;
-  height: 100%;
+  min-height: 100%;
 }
 
 .content {
@@ -29,7 +29,7 @@
 </style>
 
 <script>
-import TopNav from '@/components/TopNav/TopNav'
+import TopNav from "@/components/TopNav/TopNav";
 export default {
   props: {
     title: {
@@ -43,17 +43,17 @@ export default {
   },
   computed: {
     user() {
-      return this.$store.getters['auth/user']
+      return this.$store.getters["auth/user"];
     },
     loaded() {
-      return !this.$store.getters['app/loading']
+      return !this.$store.getters["app/loading"];
     },
     enableSideBar() {
       return (
-        this.$store.getters['app/sidebar/enabled'] &&
-        this.$store.getters['app/config'].sidebar.enabled
-      )
+        this.$store.getters["app/sidebar/enabled"] &&
+        this.$store.getters["app/config"].sidebar.enabled
+      );
     }
   }
-}
+};
 </script>

--- a/src/components/Containers/PageContainer.vue
+++ b/src/components/Containers/PageContainer.vue
@@ -1,23 +1,59 @@
 <template>
   <div class="page-container">
-    <h1 v-if="title">{{title}}</h1>
-    <slot></slot>
+    <top-nav class="top-nav" :loaded="loaded" :user="user" :sidebar="enableSideBar" v-if="user">
+      <slot name="additional-info"></slot>
+    </top-nav>
+    <div class="content">
+      <h1 v-if="title">{{title}}</h1>
+      <slot></slot>
+    </div>
   </div>
 </template>
 
 <style lang="scss">
-  .page-container {
-    background-color: $light-bg;
-  }
+.page-container {
+  background-color: $light-bg;
+  height: 100%;
+}
+
+.content {
+  padding: 1em 1.5em;
+}
+
+.top-nav {
+  width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 99;
+}
 </style>
 
 <script>
-  export default {
-    props: {
-      title: {
-        type: String,
-        required: false
-      }
+import TopNav from '@/components/TopNav/TopNav'
+export default {
+  props: {
+    title: {
+      type: String,
+      required: false
+    }
+  },
+
+  components: {
+    TopNav
+  },
+  computed: {
+    user() {
+      return this.$store.getters['auth/user']
+    },
+    loaded() {
+      return !this.$store.getters['app/loading']
+    },
+    enableSideBar() {
+      return (
+        this.$store.getters['app/sidebar/enabled'] &&
+        this.$store.getters['app/config'].sidebar.enabled
+      )
     }
   }
+}
 </script>

--- a/src/components/Containers/PageSection.vue
+++ b/src/components/Containers/PageSection.vue
@@ -47,11 +47,13 @@ export default {
   props: {
     title: {
       type: String,
-      required: true
+      required: false,
+      default: ''
     },
     subtitle: {
       type: String,
-      required: false
+      required: false,
+      default: ''
     }
   }
 }

--- a/src/components/Containers/PageSection.vue
+++ b/src/components/Containers/PageSection.vue
@@ -9,51 +9,50 @@
 </template>
 
 <style lang="scss">
-  .section-details {
-    flex: 1;
-    @media (max-width: 555px) {
-      align-items: center;
-    }
-
-    @media (max-width: 1024px) and (min-width: 556px) {
-      align-items: center;
-      margin: 0 0.5em;
-    }
+.section-details {
+  flex: 1;
+  @media (max-width: 555px) {
+    align-items: center;
   }
 
-  .page-section {
-    display: flex;
-    flex-direction: row;
-    border-bottom: 1px solid lightgray;
+  @media (max-width: 1024px) and (min-width: 556px) {
+    align-items: center;
+    margin: 0 0.5em;
+  }
+}
 
-    @media (max-width: 1024px) {
-      flex-direction: column;
-    }
+.page-section {
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid lightgray;
 
-    .section-content {
-
-      @media (min-width: 1025px) {
-        max-width: 80%;
-      }
-    }
+  @media (max-width: 1024px) {
+    flex-direction: column;
   }
 
-  .page-section:last-child {
-    border-bottom: none;
+  .section-content {
+    @media (min-width: 1025px) {
+      max-width: 80%;
+    }
   }
+}
+
+.page-section:last-child {
+  border-bottom: none;
+}
 </style>
 
 <script>
-  export default {
-    props: {
-      title: {
-        type: String,
-        required: true
-      },
-      subtitle: {
-        type: String,
-        required: false
-      }
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    subtitle: {
+      type: String,
+      required: false
     }
   }
+}
 </script>

--- a/src/components/TopNav/TopNav.vue
+++ b/src/components/TopNav/TopNav.vue
@@ -6,12 +6,9 @@
           <hamburger class="hamburger"></hamburger>
         </div>
       </div>
-      <router-link class="logo" :to="homeRoute" v-if="showLogo">
-        <quick></quick>&nbsp;Quick Dash
-      </router-link>
-      <router-link class="mobile-logo" :to="homeRoute" v-if="showMobileLogo">
-        <quick></quick>&nbsp;Quick Dash
-      </router-link>
+      <div class="additional-info">
+        <slot></slot>
+      </div>
       <div class="page-title">{{pageTitle}}</div>
       <user-menu v-if="user" :user="user"></user-menu>
     </div>
@@ -19,147 +16,165 @@
 </template>
 
 <style lang="scss" scoped>
-  .top-navigation {
-    height: 60px;
-    margin: 0;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    background: $header_background;
-    @media (max-width: 1025px) {
-      display: block;
-    }
+.top-navigation {
+  height: 60px;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  background: $header_background;
+  @media (max-width: 1025px) {
+    display: block;
   }
+}
 
-  .menu-toggle {
-    width: 65px;
-    height: 60px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: $white;
+.menu-toggle {
+  width: 65px;
+  height: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: $white;
 
-    @media (min-width: 1025px) {
-      display: none;
-    }
+  @media (min-width: 1025px) {
+    display: none;
   }
+}
 
-  .menu-toggle {
-    svg {
-      width: 30px;
-      height: 30px;
-      fill: $sidebar_hamburger_colour;
-    }
+.menu-toggle {
+  svg {
+    width: 30px;
+    height: 30px;
+    fill: $sidebar_hamburger_colour;
   }
+}
 
-  .header {
+.header {
+  width: 100%;
+  padding: 0 1em;
+  display: flex;
+  align-items: center;
+  background-color: $header_background;
+  height: 61px;
+  @media (max-width: 1025px) {
+    padding-left: 1em;
     width: 100%;
-    padding: 0 1em;
-    display: flex;
-    align-items: center;
-    background-color: $header_background;
-    height: 61px;
-    @media (max-width: 1025px) {
-      padding-left: 1em;
-      width: 100%;
-    }
+  }
+}
+
+.page-title {
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  color: $white;
+  font-size: 22px;
+  text-decoration: none;
+
+  svg {
+    height: 40px;
+    width: 45px;
+    fill: $white;
+  }
+}
+
+.mobile-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  color: $white;
+  font-size: 22px;
+  text-decoration: none;
+
+  svg {
+    height: 40px;
+    width: 45px;
+    fill: $white;
   }
 
-  .page-title {
-
+  @media (min-width: 1025px) {
+    display: none;
   }
-
-  .logo {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0;
-    color: $white;
-    font-size: 22px;
-    text-decoration: none;
-
-    svg {
-      height: 40px;
-      width: 45px;
-      fill: $white;
-    }
-  }
-
-  .mobile-logo {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0;
-    color: $white;
-    font-size: 22px;
-    text-decoration: none;
-
-    svg {
-      height: 40px;
-      width: 45px;
-      fill: $white;
-    }
-
-    @media (min-width: 1025px) {
-      display: none;
-    }
-  }
+}
 </style>
 
 <script>
-  import UserMenu from '@/components/TopNav/UserMenu'
-  import icons from '@/icons'
+import UserMenu from '@/components/TopNav/UserMenu'
+import icons from '@/icons'
 
-  export default {
-    name: 'top-nav',
-    components: {
-      UserMenu,
-      hamburger: icons.hamburger,
-      quick: icons.quick
+export default {
+  name: 'top-nav',
+  components: {
+    UserMenu,
+    hamburger: icons.hamburger,
+    quick: icons.quick
+  },
+  props: {
+    user: {
+      type: Object,
+      required: true
     },
-    props: {
-      user: {
-        type: Object,
-        required: true
-      },
-      loaded: {
-        type: Boolean,
-        required: true
-      }
+    loaded: {
+      type: Boolean,
+      required: true
+    }
+  },
+  mounted() {
+    this.headerStyle = this.checkHeaderStyle()
+    window.addEventListener('resize', () => {
+      this.headerStyle = this.checkHeaderStyle()
+    })
+  },
+  data() {
+    return {
+      headerStyle: null
+    }
+  },
+  computed: {
+    homeRoute() {
+      return this.$store.getters['app/config'].header.homeRoute || '/'
     },
-    computed: {
-      homeRoute() {
-        return this.$store.getters['app/config'].header.homeRoute || '/'
-      },
-      pageTitle() {
-        return ''
-      },
-      headerStyle() {
-        if (this.$store.getters['app/config'].sidebar.position === 'right') {
-          return 'flex-direction: row-reverse; justify-content: space-between;'
-        }
-
-        return 'justify-content: space-between'
-      },
-      showLogo() {
-        if (this.$store.getters['app/config'].header.logo) {
-          return true
-        }
-
-        return false
-      },
-      showMobileLogo() {
-        if (this.$store.getters['app/config'].header.mobileLogo) {
-          return true
-        }
-
-        return false
-      }
+    pageTitle() {
+      return ''
     },
-    methods: {
-      toggleSideBar() {
-        this.$store.commit('app/sidebar/open', !this.$store.getters['app/sidebar/open'])
+    showLogo() {
+      if (this.$store.getters['app/config'].header.logo) {
+        return true
       }
+
+      return false
+    },
+    showMobileLogo() {
+      if (this.$store.getters['app/config'].header.mobileLogo) {
+        return true
+      }
+
+      return false
+    }
+  },
+  methods: {
+    toggleSideBar() {
+      this.$store.commit(
+        'app/sidebar/open',
+        !this.$store.getters['app/sidebar/open']
+      )
+    },
+
+    checkHeaderStyle() {
+      if (this.$store.getters['app/config'].sidebar.position === 'right') {
+        return 'flex-direction: row-reverse; justify-content: space-between;'
+      }
+
+      if (window.innerWidth < 1025) {
+        return 'justify-content: flex-start'
+      }
+
+      return 'justify-content: space-between'
     }
   }
+}
 </script>

--- a/src/components/TopNav/TopNav.vue
+++ b/src/components/TopNav/TopNav.vue
@@ -110,8 +110,7 @@ export default {
   name: 'top-nav',
   components: {
     UserMenu,
-    hamburger: icons.hamburger,
-    quick: icons.quick
+    hamburger: icons.hamburger
   },
   props: {
     user: {
@@ -128,6 +127,9 @@ export default {
     window.addEventListener('resize', () => {
       this.headerStyle = this.checkHeaderStyle()
     })
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize')
   },
   data() {
     return {


### PR DESCRIPTION
## Overview
There's a need for consistency between the new mockup and the quick-dash-framework

Related issues: #

## The problem
The back button and the page title needs to be in the top bar but currently sits within the page container component
...

## How I resolved it
I moved the top-bar from the App component to the page container component and wired it to accept slot
...

## How to verify it
N/A

## Questions
N/A

## Notes
N/A

## Screenshots

*all style changes require before and after screenshots*
### Before
<img width="1279" alt="Screenshot 2019-10-02 at 11 12 28 AM" src="https://user-images.githubusercontent.com/22296251/66036879-db61f680-e4fd-11e9-83e8-606b2e7a0ae3.png">

### After
<img width="1280" alt="Screenshot 2019-10-02 at 11 10 54 AM" src="https://user-images.githubusercontent.com/22296251/66036887-e2890480-e4fd-11e9-873c-7d712f00118a.png">

Notify the following people: @darrynten @tammygermany @igorsergiichuk @steveops @humanityjs @fergusdixon
