### PR TITLE
Widget

### DIFF
--- a/src/components/SideBar/SideBar.vue
+++ b/src/components/SideBar/SideBar.vue
@@ -8,7 +8,10 @@
     >
       <component v-if="showLogo" :is="logo"></component>
     </router-link>
-    <user-profile v-if="showUserProfile" :user="user"></user-profile>
+    <template v-if="showSideBarHeaderComponent">
+      <user-profile :user="user" v-if="!sideBarHeaderComponent"></user-profile>
+      <component :is="sideBarHeaderComponent" v-else-if="sideBarHeaderComponent"></component>
+    </template>
     <div class="menu-items">
       <side-bar-menu-item
         v-for="menu in menus"
@@ -91,6 +94,16 @@ export default {
     sideBarFooterComponent() {
       if (this.$store.getters['app/config'].sidebar.customSideBarFooterComponent) {
         return this.$store.getters['app/config'].sidebar.customSideBarFooterComponent.component
+      }
+    },
+    showSideBarHeaderComponent() {
+      if (this.$store.getters['app/config'].sidebar.customSideBarHeaderComponent) {
+        return this.$store.getters['app/config'].sidebar.customSideBarHeaderComponent.enabled
+      }
+    },
+    sideBarHeaderComponent() {
+      if (this.$store.getters['app/config'].sidebar.customSideBarHeaderComponent) {
+        return this.$store.getters['app/config'].sidebar.customSideBarHeaderComponent.component
       }
     }
   },

--- a/src/config/sidebar.js
+++ b/src/config/sidebar.js
@@ -8,12 +8,15 @@ export default {
   logo: () => {
     return icons.quick
   },
-  profile: true,
   account: true,
   highlight: true,
   icons: true,
   customSideBarFooterComponent: {
     enabled: false,
     component: null
+  },
+  customSideBarHeaderComponent: {
+    enabled: true,
+    component: ''
   }
 }

--- a/test/unit/specs/components/SideBar/SideBar.spec.js
+++ b/test/unit/specs/components/SideBar/SideBar.spec.js
@@ -266,7 +266,7 @@ describe('SideBar.vue', () => {
     expect(sidebar.find('router-link.logo').exists()).to.equal(true)
   })
 
-  it('Shows custom components', () => {
+  it('Shows custom header components', () => {
     const customSideBarFooterComponentStub = sinon.stub().returns('xxx')
 
     const sidebar = shallowMount(SideBar, {
@@ -325,5 +325,66 @@ describe('SideBar.vue', () => {
     })
 
     expect(customSideBarFooterComponentStub.called).to.equal(true)
+  })
+
+  it('Shows custom header components', () => {
+    const customSideBarHeaderComponentStub = sinon.stub().returns('xxx')
+
+    const sidebar = shallowMount(SideBar, {
+      localVue,
+      propsData: {
+        user: {},
+        menus: [
+          {
+            name: 'home',
+            path: '/',
+            meta: {
+              icon: 'fa fa-home',
+              label: 'Home',
+              main: true
+            }
+          }
+        ]
+      },
+      mocks: {
+        $route: {
+          name: 'Home',
+          label: 'Home',
+          matched: []
+        },
+        $store: {
+          getters: {
+            'app/sidebar/open': true,
+            'app/config': {
+              sidebar: {
+                profile: true,
+                logout: true,
+                icons: true,
+                highlight: false,
+                customSideBarHeaderComponent: {
+                  enabled: true,
+                  component: customSideBarHeaderComponentStub
+                }
+              },
+              header: {
+                homeRoute: '/home'
+              }
+            }
+          },
+          commit: sinon.spy()
+        },
+        $auth: {
+          user() {
+            return {
+              first_name: 'fn',
+              last_name: 'ln'
+            }
+          },
+          logout: sinon.stub().resolves(true)
+        }
+      }
+    })
+
+    expect(customSideBarHeaderComponentStub.called).to.equal(true)
   })
 })


### PR DESCRIPTION
## Overview

Related issues: https://github.com/UnicornGlobal/extravallis-dashboard/issues/47

## The problem

The widget showing the completion percentage of the profile should be added to profile

## How I resolved it

Edited the `SideBar` component adding the optional component that is rendered if the host app selects it in the config -> `CustomSideBarComponent`.
There are 2 props to be passed to ` customSideBarComponent` preset:
    ```
enabled: true / false
component: require('path to the component').default

## How to verify it

1. Edit the host app's config to have the Custom Component and check the sideBar
2. Edit the framework sidebar config and link some component

Notify the following people: @darrynten @tammygermany @igorsergiichuk
