### PR TITLE
Support "any role" routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ This may change in the future but is the convention for now.
 **NB** You *must* att `static:true` to the `meta` field of your static
 routes. This may change in the future but is convention for now.
 
+#### Allow Any Role
+
+To allow any role on a route just set role to `false`
+
 ### Config Loading
 
 The values in `/src/config/*.js` will be overridden by any values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicorns/quick-dash-framework",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Quick Dashboard Framework",
   "author": "Unicorn Global et al",
   "license": "MIT",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -96,6 +96,10 @@ function filterRoutesByRole(routes, user) {
   const processedRoutes = []
 
   for (let i = 0; i < routes.length; i++) {
+    if (routes[i].role === false) {
+      processedRoutes.push(routes[i])
+    }
+
     if (routes[i].role && userHasRole(user, routes[i].role)) {
       processedRoutes.push(routes[i])
     }


### PR DESCRIPTION
Adds support for routes that allow for any role

Just set `route: false` in the config to have it always be present